### PR TITLE
Make content_length_limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,5 @@ ETHERSCAN_KEY=
 API_KEY=
 # Port to run the simulator on, defaults to 8080
 PORT=
+# Maximum size for incoming requests (in KB), defaults to 16
+MAX_REQUEST_SIZE=

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub fork_url: Option<String>,
     pub etherscan_key: Option<String>,
     pub api_key: Option<String>,
+    pub max_request_size: u64,
 }
 
 pub fn config() -> Config {
@@ -24,12 +25,18 @@ fn load_config() -> Config {
         .ok()
         .filter(|k| !k.is_empty());
     let api_key = std::env::var("API_KEY").ok().filter(|k| !k.is_empty());
+    let max_request_size = std::env::var("MAX_REQUEST_SIZE")
+        .unwrap_or("16".to_string())
+        .parse::<u64>()
+        .expect("MAX_REQUEST_SIZE must be a valid u64")
+        * 1024;
 
     Config {
         fork_url,
         port,
         etherscan_key,
         api_key,
+        max_request_size,
     }
 }
 


### PR DESCRIPTION
Currently `content_length_limit` is hardcoded to 16KB, leading to errors of kind

> Handling rejection: Rejection(PayloadTooLarge)
unhandled rejection: Rejection(PayloadTooLarge)
INFO  ts::api      > 127.0.0.1:52125 "POST /api/v1/simulate HTTP/1.1" 500 "-" "curl/7.79.1" 686.917µs

when trying to simulate batched intent beauties like https://etherscan.io/tx/0x8d1feb91a6ca9398607b7f02177b61425b1a64d511fcccb9ef7a60becdde0a7b

This PR adds an optional config value that allows to configure this value and allow processing larger request bodies.

### Test Plan

Above mentioned transaction simulates successfully when `MAX_REQUEST_SIZE=32`